### PR TITLE
Bugfix: 修复SmaliTool在修改字段的时候replace函数限制不严导致某些情况下smali中的类名会被修改成错误的类名的bug

### DIFF
--- a/auto-patch-plugin/src/main/java/com/meituan/robust/utils/SmaliTool.java
+++ b/auto-patch-plugin/src/main/java/com/meituan/robust/utils/SmaliTool.java
@@ -137,7 +137,8 @@ public class SmaliTool {
                 // 字段处理
                 //sget-object v4, Lcom/sankuai/meituan/fingerprint/FingerprintConfig;->accelerometerInfoList:Ljava/util/List;
                 String fieldName = result.substring(packageNameIndex + packageNameList.get(index).length() + 3, result.lastIndexOf(":"));
-                result = result.replace(fieldName, getObscuredMemberName(packageNameList.get(index).replaceAll("/", "\\."), fieldName));
+                // 前后都加上 "->" 是为了避免类名中包含字段名时，类名被误修改导致patch生成错误
+                result = result.replaceFirst("->" + fieldName, "->" + getObscuredMemberName(packageNameList.get(index).replaceAll("/", "\\."), fieldName));
             }
         }
         for (int index = 0; packageNameList != null && index < packageNameList.size(); index++) {


### PR DESCRIPTION
最近在试用Robust的过程中发现一个bug，为避免泄密就不贴真实代码了，转换成以下的case：

先假设以下是mapping.txt 中的内容：

com.example.Test -> com.example.l:
    com.example.Test$Companion Companion -> b

com.example.Test$Companion -> com.example.l$a:

Test.Companion.xxx()这句话会生成
//sget-object v4, Lcom/example/Test;->Companion:Lcom/example/Test$Companion;
如果按照原有逻辑，
会导致先翻译字段变成
//sget-object v4, Lcom/example/Test;->b:Lcom/example/Test$b;
再翻译类名变成
//sget-object v4, Lcom/example/l;->b:Lcom/example/l$b;
而正确的结果显然是
//sget-object v4, Lcom/example/l;->b:Lcom/example/l$a;



Change-Id: Iccf4f5896eb72dd254ef05a12d74c6c07f074aa1