### PR TITLE
fix 一个方法在基类中时，热修复包反射调用会找不到该调用的方法的bug

### DIFF
--- a/autopatchbase/src/main/java/com/meituan/robust/utils/EnhancedRobustUtils.java
+++ b/autopatchbase/src/main/java/com/meituan/robust/utils/EnhancedRobustUtils.java
@@ -48,10 +48,10 @@ public class EnhancedRobustUtils {
             for (Class<?> clazz = object.getClass(); clazz != null; clazz = clazz.getSuperclass()) {
                 try {
                     method = clazz.getDeclaredMethod(methodName, parameterTypes);
-                    if (!method.isAccessible()) {
-                        method.setAccessible(true);
-                    }
-                    if (null == declaringClass || clazz.equals(declaringClass)) {
+                    if (method != null) {
+                        if (!method.isAccessible()) {
+                            method.setAccessible(true);
+                        }
                         return method;
                     }
                 } catch (Exception e) {


### PR DESCRIPTION
Change-Id: I9f0a311419c33a684465a8b3e7cf550f366dc026

看样子目前的实现会导致在一个方法在基类中定义的话，getDeclaredMethod根本就不会返回这个方法。