### PR TITLE
修复Auto-Patch插件中对新增class的继承或实现方法名没混淆的bug

### DIFF
--- a/auto-patch-plugin/src/main/java/com/meituan/robust/autopatch/ReadMapping.java
+++ b/auto-patch-plugin/src/main/java/com/meituan/robust/autopatch/ReadMapping.java
@@ -65,7 +65,7 @@ public class ReadMapping {
                     classMapping.setValueName(line.split("->")[1].substring(0, line.split("->")[1].length() - 1).trim());
                     line = reader.readLine();
                     while (line != null) {
-                        line=line.trim();
+                        line = line.trim();
                         if (line.endsWith(":")) {
                             needBacktrace = true;
                             break;
@@ -107,12 +107,16 @@ public class ReadMapping {
         return usedInModifiedClassMappingInfo.get(classname);
     }
 
+    public void setClassMapping(String classname, ClassMapping classMapping) {
+        usedInModifiedClassMappingInfo.put(classname, classMapping);
+    }
+
     public ClassMapping getClassMappingOrDefault(String classname) {
-        ClassMapping defaultClassMapping=new ClassMapping();
-        if(!Config.supportProGuard){
+        ClassMapping defaultClassMapping = new ClassMapping();
+        if (!Config.supportProGuard) {
             defaultClassMapping.setValueName(classname);
         }
-        return usedInModifiedClassMappingInfo.getOrDefault(classname,defaultClassMapping);
+        return usedInModifiedClassMappingInfo.getOrDefault(classname, defaultClassMapping);
     }
 
     /***


### PR DESCRIPTION
这个bug是这么发现的 retrofit2 有这么一个接口 

<pre>
public interface Callback<T> {
  void onResponse(Call<T> call, SsResponse<T> response);
  void onFailure(Call<T> call, Throwable t);
}
</pre>

混淆后假设 onResponse 变成 a， onFailure变成 b

原来的接口实现是OldCallback，现在要在某些情况下用Patch新增的NewCallback
这样NewCallback中的onResponse和onFailure必须被混淆成a和b。

但现有逻辑smali混淆过后onResponse和onFailure函数名仍然是明文。



Change-Id: Ic4f8226bd201ed48d06cc826723c767319a5a96d