### PR TITLE
feat: 增加补丁失效功能，支持补丁修复内容发生异常时业务方可以及时监控并失效

### DIFF
--- a/app/robust.xml
+++ b/app/robust.xml
@@ -21,6 +21,9 @@
         <catchReflectException>true</catchReflectException>
         <!--<catchReflectException>false</catchReflectException>-->
 
+        <!--是否检测补丁异常，自动回滚补丁-->
+        <rollbackWhenException>true</rollbackWhenException>
+
         <!--是否在补丁加上log，建议上线的时候这个开关的值为false，测试的时候为true-->
         <!--<patchLog>true</patchLog>-->
         <patchLog>false</patchLog>

--- a/auto-patch-plugin/src/main/groovy/com/meituan/robust/autopatch/ReadXML.groovy
+++ b/auto-patch-plugin/src/main/groovy/com/meituan/robust/autopatch/ReadXML.groovy
@@ -47,6 +47,9 @@ class ReadXML {
         if (robust.switch.catchReflectException.text() != null && "" != robust.switch.catchReflectException.text())
             Config.catchReflectException = Boolean.valueOf(robust.switch.catchReflectException.text()).booleanValue();
 
+        if (robust.switch.rollbackWhenException.text() != null && "" != robust.switch.rollbackWhenException.text())
+            Config.rollbackWhenException = Boolean.valueOf(robust.switch.rollbackWhenException.text()).booleanValue();
+
         if (robust.switch.patchLog.text() != null && "" != robust.switch.patchLog.text())
             Constants.isLogging = Boolean.valueOf(robust.switch.patchLog.text()).booleanValue();
 

--- a/auto-patch-plugin/src/main/java/com/meituan/robust/autopatch/Config.java
+++ b/auto-patch-plugin/src/main/java/com/meituan/robust/autopatch/Config.java
@@ -23,6 +23,7 @@ import static com.meituan.robust.Constants.DEFAULT_MAPPING_FILE;
 
 public final class Config {
     public static boolean catchReflectException = false;
+    public static boolean rollbackWhenException = false;
     public static boolean supportProGuard = true;
     public static boolean isLogging = true;
     public static boolean isManual = false;
@@ -44,6 +45,7 @@ public final class Config {
 
     public static void init() {
         catchReflectException = false;
+        rollbackWhenException = false;
         isLogging = true;
         isManual = false;
         patchPackageName = Constants.PATCH_PACKAGENAME;

--- a/autopatchbase/src/main/java/com/meituan/robust/RollbackListener.java
+++ b/autopatchbase/src/main/java/com/meituan/robust/RollbackListener.java
@@ -1,0 +1,12 @@
+package com.meituan.robust;
+
+/**
+ * @author feelschaotic
+ * @create 2019/7/30.
+ */
+
+public interface RollbackListener {
+    void onRollback(String methodsId, String methodLongName, Throwable e);
+
+    boolean getRollback(String methodsId);
+}

--- a/autopatchbase/src/main/java/com/meituan/robust/RollbackManager.java
+++ b/autopatchbase/src/main/java/com/meituan/robust/RollbackManager.java
@@ -1,0 +1,37 @@
+package com.meituan.robust;
+
+public class RollbackManager {
+
+    private RollbackListener listener;
+
+
+    private static class RollbackManagerHolder {
+        private static final RollbackManager INSTANCE = new RollbackManager();
+    }
+
+    public static RollbackManager getInstance() {
+        return RollbackManagerHolder.INSTANCE;
+    }
+
+    private RollbackManager() {
+    }
+
+    public void setRollbackListener(RollbackListener listener) {
+        this.listener = listener;
+    }
+
+    public boolean getRollback(String methodsId) {
+        return listener != null && listener.getRollback(methodsId);
+    }
+
+    /**
+     * 当异常时重置标志位，表明这是一个旧补丁
+     *
+     * @return
+     */
+    public void notifyOnException(String methodsId, String methodLongName, Throwable e) {
+        if (listener != null) {
+            listener.onRollback(methodsId, methodLongName, e);
+        }
+    }
+}

--- a/autopatchbase/src/main/java/com/meituan/robust/utils/PatchTemplate.java
+++ b/autopatchbase/src/main/java/com/meituan/robust/utils/PatchTemplate.java
@@ -17,6 +17,9 @@ public class PatchTemplate implements ChangeQuickRedirect {
 
     private static final Map<Object, Object> keyToValueRelation = new WeakHashMap<>();
 
+    private String methodsId;
+    private String methodLongName;
+
     @Override
     public Object accessDispatch(String methodName, Object[] paramArrayOfObject) {
         return null;


### PR DESCRIPTION
背景：
为了增强鲁棒性，需要增加异常防范机制，当补丁内容发生异常时，希望及时监控到，并让补丁立即失效，避免增加报错率。

功能说明：
支持业务方实现回滚监听器，监听并记录补丁失效状态

备注：
1. 有新补丁下载时业务方需要自己重置下本地的标志位，清空所有补丁回滚状态
2. 详细示例见app MainActivity