### PR TITLE
fix: xxx class is frozen

### DIFF
--- a/gradle-plugin/src/main/groovy/robust/gradle/plugin/asm/AsmInsertImpl.java
+++ b/gradle-plugin/src/main/groovy/robust/gradle/plugin/asm/AsmInsertImpl.java
@@ -59,6 +59,7 @@ public class AsmInsertImpl extends InsertcodeStrategy {
                 zipFile(ctClass.toBytecode(), outStream, ctClass.getName().replaceAll("\\.", "/") + ".class");
 
             }
+            ctClass.defrost();
         }
         outStream.close();
     }


### PR DESCRIPTION
修复插桩异常#298 xxx class is frozen.
复现步骤:
其他插件依赖Javassist 3.22.0-GA及以上版本;
问题原因:
AsmInsertImpl遍历ctClass的list, 按先外部类后内部类的顺序调用ctClass.setModifiers(); Javassist 3.22.0及以上版本实现: 如果ctClass是内部类会在setModifiers后从classPool缓存中取外部类的ctClass并checkModifiers(), 而此时外部类已经setModifiers并标记为frozen.
解决方法:
ctClass.setModifiers()和ctClass.toByteCode()后调用当前ctClass.defrost()