### PR TITLE
Features:针对Java8的Lambda表达式编译支持可选插桩

### DIFF
--- a/app/robust.xml
+++ b/app/robust.xml
@@ -32,6 +32,10 @@
         <!--项目是否支持ASM进行插桩，默认使用ASM，推荐使用ASM，Javaassist在容易和其他字节码工具相互干扰-->
         <useAsm>true</useAsm>
         <!--<useAsm>false</useAsm>-->
+
+        <!--针对Java8级别的Lambda表达式，编译为private级别的javac函数，此时由开发者决定是否进行插桩处理-->
+        <forceInsertLambda>true</forceInsertLambda>
+<!--        <forceInsertLambda>false</forceInsertLambda>-->
     </switch>
 
     <!--需要热补的包名或者类名，这些包名下的所有类都被会插入代码-->

--- a/gradle-plugin/src/main/groovy/robust/gradle/plugin/InsertcodeStrategy.java
+++ b/gradle-plugin/src/main/groovy/robust/gradle/plugin/InsertcodeStrategy.java
@@ -34,17 +34,22 @@ public abstract class InsertcodeStrategy {
 
     //a switch control whether need to filter method in exceptMethodList, if false ,exceptMethodList will be ignored
     protected boolean isExceptMethodLevel = false;
+
+    //a switch control whether need to insert code into lambda function
+    protected boolean isForceInsertLambda = false;
+
     protected AtomicInteger insertMethodCount = new AtomicInteger(0);
     //record every method with unique method number, use LinkedHashMap to keep order for printing
     public HashMap<String, Integer> methodMap = new LinkedHashMap<>();
 
-    public InsertcodeStrategy(List<String> hotfixPackageList, List<String> hotfixMethodList, List<String> exceptPackageList, List<String> exceptMethodList, boolean isHotfixMethodLevel, boolean isExceptMethodLevel) {
+    public InsertcodeStrategy(List<String> hotfixPackageList, List<String> hotfixMethodList, List<String> exceptPackageList, List<String> exceptMethodList, boolean isHotfixMethodLevel, boolean isExceptMethodLevel, boolean isForceInsertLambda) {
         this.hotfixPackageList = hotfixPackageList;
         this.hotfixMethodList = hotfixMethodList;
         this.exceptPackageList = exceptPackageList;
         this.exceptMethodList = exceptMethodList;
         this.isHotfixMethodLevel = isHotfixMethodLevel;
         this.isExceptMethodLevel = isExceptMethodLevel;
+        this.isForceInsertLambda = isForceInsertLambda;
         insertMethodCount.set(0);
     }
 

--- a/gradle-plugin/src/main/groovy/robust/gradle/plugin/RobustTransform.groovy
+++ b/gradle-plugin/src/main/groovy/robust/gradle/plugin/RobustTransform.groovy
@@ -31,6 +31,8 @@ class RobustTransform extends Transform implements Plugin<Project> {
     private static boolean isForceInsert = false;
 //    private static boolean useASM = false;
     private static boolean useASM = true;
+    private static boolean isForceInsertLambda = false;
+
     def robust
     InsertcodeStrategy insertcodeStrategy;
 
@@ -110,6 +112,10 @@ class RobustTransform extends Transform implements Plugin<Project> {
         else
             isForceInsert = false
 
+        if (robust.switch.forceInsertLambda != null && "true".equals(String.valueOf(robust.switch.forceInsertLambda.text())))
+            isForceInsertLambda = true;
+        else
+            isForceInsertLambda = false;
     }
 
     @Override
@@ -155,10 +161,10 @@ class RobustTransform extends Transform implements Plugin<Project> {
         def box = ConvertUtils.toCtClasses(inputs, classPool)
         def cost = (System.currentTimeMillis() - startTime) / 1000
 //        logger.quiet "check all class cost $cost second, class count: ${box.size()}"
-        if(useASM){
-            insertcodeStrategy=new AsmInsertImpl(hotfixPackageList,hotfixMethodList,exceptPackageList,exceptMethodList,isHotfixMethodLevel,isExceptMethodLevel);
-        }else {
-            insertcodeStrategy=new JavaAssistInsertImpl(hotfixPackageList,hotfixMethodList,exceptPackageList,exceptMethodList,isHotfixMethodLevel,isExceptMethodLevel);
+        if (useASM) {
+            insertcodeStrategy = new AsmInsertImpl(hotfixPackageList, hotfixMethodList, exceptPackageList, exceptMethodList, isHotfixMethodLevel, isExceptMethodLevel, isForceInsertLambda);
+        } else {
+            insertcodeStrategy = new JavaAssistInsertImpl(hotfixPackageList, hotfixMethodList, exceptPackageList, exceptMethodList, isHotfixMethodLevel, isExceptMethodLevel, isForceInsertLambda);
         }
         insertcodeStrategy.insertCode(box, jarFile);
         writeMap2File(insertcodeStrategy.methodMap, Constants.METHOD_MAP_OUT_PATH)

--- a/gradle-plugin/src/main/groovy/robust/gradle/plugin/asm/AsmInsertImpl.java
+++ b/gradle-plugin/src/main/groovy/robust/gradle/plugin/asm/AsmInsertImpl.java
@@ -41,8 +41,8 @@ import robust.gradle.plugin.InsertcodeStrategy;
 public class AsmInsertImpl extends InsertcodeStrategy {
 
 
-    public AsmInsertImpl(List<String> hotfixPackageList, List<String> hotfixMethodList, List<String> exceptPackageList, List<String> exceptMethodList, boolean isHotfixMethodLevel, boolean isExceptMethodLevel) {
-        super(hotfixPackageList, hotfixMethodList, exceptPackageList, exceptMethodList, isHotfixMethodLevel, isExceptMethodLevel);
+    public AsmInsertImpl(List<String> hotfixPackageList, List<String> hotfixMethodList, List<String> exceptPackageList, List<String> exceptMethodList, boolean isHotfixMethodLevel, boolean isExceptMethodLevel, boolean isForceInsertLambda) {
+        super(hotfixPackageList, hotfixMethodList, exceptPackageList, exceptMethodList, isHotfixMethodLevel, isExceptMethodLevel, isForceInsertLambda);
     }
 
     @Override
@@ -125,7 +125,7 @@ public class AsmInsertImpl extends InsertcodeStrategy {
             //@warn 这部分代码请重点review一下，判断条件写错会要命
             //这部分代码请重点review一下，判断条件写错会要命
             // synthetic 方法暂时不aop 比如AsyncTask 会生成一些同名 synthetic方法,对synthetic 以及private的方法也插入的代码，主要是针对lambda表达式
-            if (((access & Opcodes.ACC_SYNTHETIC) != 0) && ((access & Opcodes.ACC_PRIVATE) == 0)) {
+            if (!isForceInsertLambda && ((access & Opcodes.ACC_SYNTHETIC) != 0) && ((access & Opcodes.ACC_PRIVATE) == 0)) {
                 return false;
             }
             if ((access & Opcodes.ACC_ABSTRACT) != 0) {

--- a/gradle-plugin/src/main/groovy/robust/gradle/plugin/javaassist/JavaAssistInsertImpl.java
+++ b/gradle-plugin/src/main/groovy/robust/gradle/plugin/javaassist/JavaAssistInsertImpl.java
@@ -35,8 +35,8 @@ import robust.gradle.plugin.InsertcodeStrategy;
 
 public class JavaAssistInsertImpl extends InsertcodeStrategy {
 
-    public JavaAssistInsertImpl(List<String> hotfixPackageList, List<String> hotfixMethodList, List<String> exceptPackageList, List<String> exceptMethodList, boolean isHotfixMethodLevel, boolean isExceptMethodLevel) {
-        super(hotfixPackageList, hotfixMethodList, exceptPackageList, exceptMethodList, isHotfixMethodLevel, isExceptMethodLevel);
+    public JavaAssistInsertImpl(List<String> hotfixPackageList, List<String> hotfixMethodList, List<String> exceptPackageList, List<String> exceptMethodList, boolean isHotfixMethodLevel, boolean isExceptMethodLevel, boolean isForceInsertLambda) {
+        super(hotfixPackageList, hotfixMethodList, exceptPackageList, exceptMethodList, isHotfixMethodLevel, isExceptMethodLevel, isForceInsertLambda);
     }
 
     @Override
@@ -109,7 +109,7 @@ public class JavaAssistInsertImpl extends InsertcodeStrategy {
         }
 
         // synthetic 方法暂时不aop 比如AsyncTask 会生成一些同名 synthetic方法,对synthetic 以及private的方法也插入的代码，主要是针对lambda表达式
-        if ((it.getModifiers() & AccessFlag.SYNTHETIC) != 0 && !AccessFlag.isPrivate(it.getModifiers())) {
+        if (!isForceInsertLambda && (it.getModifiers() & AccessFlag.SYNTHETIC) != 0 && !AccessFlag.isPrivate(it.getModifiers())) {
             return false;
         }
         if (it.getMethodInfo().isConstructor()) {


### PR DESCRIPTION
背景：
1、很大部分第三方库默认集成Java8Lambda表达式，不在使用retroLambda库，如果不弃用retroLambda，则部分第三方无法使用
2、工程如果集成Java8的Lambda表达式，编译插桩时，原代码跳过Lambda插桩，在目前日趋使用频繁的Lambda表达式情况下，不支持插桩修复会比较麻烦。

功能说明：
1、在robust.xml中开放开关，支持lambda表达式的强制插桩，增强修复可能性

备注：
该修复已经在我方工程中上线较长时间，目前稳定可控，未出现大问题。
