### PR TITLE
[#422]:Android R系统上，安装异常

### DIFF
--- a/app/src/main/java/com/meituan/sample/PatchManipulateImp.java
+++ b/app/src/main/java/com/meituan/sample/PatchManipulateImp.java
@@ -46,8 +46,8 @@ public class PatchManipulateImp extends PatchManipulate {
     protected List<Patch> fetchPatchList(Context context) {
         //将app自己的robustApkHash上报给服务端，服务端根据robustApkHash来区分每一次apk build来给app下发补丁
         //apkhash is the unique identifier for  apk,so you cannnot patch wrong apk.
-        String robustApkHash = RobustApkHashUtils.readRobustApkHash(context);
-        Log.w("robust","robustApkHash :" + robustApkHash);
+//        String robustApkHash = RobustApkHashUtils.readRobustApkHash(context);
+//        Log.w("robust","robustApkHash :" + robustApkHash);
         //connect to network to get patch list on servers
         //在这里去联网获取补丁列表
         Patch patch = new Patch();

--- a/gradle-plugin/src/main/groovy/robust/gradle/plugin/RobustTransform.groovy
+++ b/gradle-plugin/src/main/groovy/robust/gradle/plugin/RobustTransform.groovy
@@ -59,7 +59,7 @@ class RobustTransform extends Transform implements Plugin<Project> {
             }
             if (!isDebugTask) {
                 project.android.registerTransform(this)
-                project.afterEvaluate(new RobustApkHashAction())
+//                project.afterEvaluate(new RobustApkHashAction())
                 logger.quiet "Register robust transform successful !!!"
             }
             if (null != robust.switch.turnOnRobust && !"true".equals(String.valueOf(robust.switch.turnOnRobust))) {


### PR DESCRIPTION
原因:gradle 3.5.0+时向apk写入apkhash文件存在再压缩操作，而Android R不允许对resources.arsc进行压缩
解决方案:去掉写apkhash的操作，这块属于补丁加载策略的逻辑，正如wiki所说“对于补丁的加载策略不同的业务方有着不同的需求”，各业务去定制加载策略即可。

Signed-off-by: Gain <perfecter.gen@gmail.com>