### PR TITLE
升级javassist到3.22.0-GA版本，过滤module-info.class，解决 java.io.IOException: invalid constant type: 19 at 5

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,6 +70,6 @@ dependencies {
     compile 'com.squareup.okhttp:okhttp:2.5.0'
     compile 'com.google.code.gson:gson:2.3.1'
     compile 'com.android.support:design:25.4.0'
-    compile 'org.javassist:javassist:3.20.0-GA'
+    compile 'org.javassist:javassist:3.22.0-GA'
     compile project(path: ':patch')
 }

--- a/auto-patch-plugin/build.gradle
+++ b/auto-patch-plugin/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     compile gradleApi()
     compile localGroovy()
     compile 'com.android.tools.build:gradle:2.1.0'
-    compile 'org.javassist:javassist:3.20.0-GA'
+    compile 'org.javassist:javassist:3.22.0-GA'
 //    compile 'com.meituan.robust:autopatchbase:' + VERSION_NAME
     compile project(':autopatchbase')
 }

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compile gradleApi()
     compile localGroovy()
     compile 'com.android.tools.build:gradle:2.1.0'
-    compile 'org.javassist:javassist:3.20.0-GA'
+    compile 'org.javassist:javassist:3.22.0-GA'
     compile fileTree(dir: "./src/main/libs", include: ['*.jar'])
     compile project(':autopatchbase')
 //    compile 'com.meituan.robust:autopatchbase:0.4.93'

--- a/gradle-plugin/src/main/groovy/robust/gradle/plugin/asm/AsmInsertImpl.java
+++ b/gradle-plugin/src/main/groovy/robust/gradle/plugin/asm/AsmInsertImpl.java
@@ -50,6 +50,13 @@ public class AsmInsertImpl extends InsertcodeStrategy {
         ZipOutputStream outStream = new JarOutputStream(new FileOutputStream(jarFile));
         //get every class in the box ,ready to insert code
         for (CtClass ctClass : box) {
+            /**
+             * 过滤掉javassis 从3.20.0-GA升级到3.22.0-GA产生的module-info.class
+             * 因为3.22.0-GA是使用java9编译的，会产生一个叫module-info.class的文件类
+             */
+            if ("META-INF.versions.9.module-info".equals(ctClass.getName())) {
+                continue;
+            }
             //change modifier to public ,so all the class in the apk will be public ,you will be able to access it in the patch
             ctClass.setModifiers(AccessFlag.setPublic(ctClass.getModifiers()));
             if (isNeedInsertClass(ctClass.getName()) && !(ctClass.isInterface() || ctClass.getDeclaredMethods().length < 1)) {


### PR DESCRIPTION
**背景：
  gradle版本：6.5
  gradle插件版本：3.6.3
  在打开robust插件编译过程中出现一下错误**
  java.lang.RuntimeException: java.io.IOException: invalid constant type: 19 at 5
  at javassist.CtClassType.getClassFile2(CtClassType.java:211)
  at javassist.CtClassType.getModifiers(CtClassType.java:407)
  at robust.gradle.plugin.asm.AsmInsertImpl.insertCode(AsmInsertImpl.java:54)
 经过排查，出现的原因是javassist版本过低导致，因此此提交做了一下两项工作：
1、升级javassist，从3.20.0-GA升级到3.22.0-GA。
2、在类处理过程中，过滤掉3.22.0-GA版本产生的module-info.class，否则在编译的过程中会出现一下错误：
![image](https://user-images.githubusercontent.com/8807159/94409644-0b8fb400-01a9-11eb-9612-9857c80bf1f0.png)
