### PR TITLE
修复第三方库混淆出r文件与R文件冲突导致报错问题。eg:Caused by: java.lang.RuntimeException: ca…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,6 +70,6 @@ dependencies {
     compile 'com.squareup.okhttp:okhttp:2.5.0'
     compile 'com.google.code.gson:gson:2.3.1'
     compile 'com.android.support:design:25.4.0'
-    compile 'org.javassist:javassist:3.20.0-GA'
+    compile 'org.javassist:javassist:3.22.0-GA'
     compile project(path: ':patch')
 }

--- a/auto-patch-plugin/build.gradle
+++ b/auto-patch-plugin/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     compile gradleApi()
     compile localGroovy()
     compile 'com.android.tools.build:gradle:2.1.0'
-    compile 'org.javassist:javassist:3.20.0-GA'
+    compile 'org.javassist:javassist:3.22.0-GA'
 //    compile 'com.meituan.robust:autopatchbase:' + VERSION_NAME
     compile project(':autopatchbase')
 }

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compile gradleApi()
     compile localGroovy()
     compile 'com.android.tools.build:gradle:2.1.0'
-    compile 'org.javassist:javassist:3.20.0-GA'
+    compile 'org.javassist:javassist:3.22.0-GA'
     compile fileTree(dir: "./src/main/libs", include: ['*.jar'])
     compile project(':autopatchbase')
 //    compile 'com.meituan.robust:autopatchbase:0.4.93'

--- a/gradle-plugin/src/main/groovy/robust/gradle/plugin/ConvertUtils.groovy
+++ b/gradle-plugin/src/main/groovy/robust/gradle/plugin/ConvertUtils.groovy
@@ -12,27 +12,28 @@ import java.util.regex.Matcher
  * Created by mivanzhang on 16/11/3.
  */
 class ConvertUtils {
-    static List<CtClass> toCtClasses(Collection<TransformInput> inputs, ClassPool classPool) {
-        List<String> classNames = new ArrayList<>()
+    static List<CtClass> toCtClasses(Collection<TransformInput> inputs, ClassPool directoryClassPool, ClassPool jarClassPool) {
+        List<String> directoryClassNames = new ArrayList<>()
+        List<String> jarClassNames = new ArrayList<>()
         List<CtClass> allClass = new ArrayList<>();
         def startTime = System.currentTimeMillis()
         inputs.each {
             it.directoryInputs.each {
                 def dirPath = it.file.absolutePath
-                classPool.insertClassPath(it.file.absolutePath)
+                directoryClassPool.insertClassPath(it.file.absolutePath)
                 org.apache.commons.io.FileUtils.listFiles(it.file, null, true).each {
                     if (it.absolutePath.endsWith(SdkConstants.DOT_CLASS)) {
                         def className = it.absolutePath.substring(dirPath.length() + 1, it.absolutePath.length() - SdkConstants.DOT_CLASS.length()).replaceAll(Matcher.quoteReplacement(File.separator), '.')
-                        if(classNames.contains(className)){
+                        if(directoryClassNames.contains(className)){
                             throw new RuntimeException("You have duplicate classes with the same name : "+className+" please remove duplicate classes ")
                         }
-                        classNames.add(className)
+                        directoryClassNames.add(className)
                     }
                 }
             }
 
             it.jarInputs.each {
-                classPool.insertClassPath(it.file.absolutePath)
+                jarClassPool.insertClassPath(it.file.absolutePath)
                 def jarFile = new JarFile(it.file)
                 Enumeration<JarEntry> classes = jarFile.entries();
                 while (classes.hasMoreElements()) {
@@ -40,24 +41,33 @@ class ConvertUtils {
                     String className = libClass.getName();
                     if (className.endsWith(SdkConstants.DOT_CLASS)) {
                         className = className.substring(0, className.length() - SdkConstants.DOT_CLASS.length()).replaceAll('/', '.')
-                        if(classNames.contains(className)){
+                        if(jarClassNames.contains(className) || directoryClassNames.contains(className)){
                             throw new RuntimeException("You have duplicate classes with the same name : "+className+" please remove duplicate classes ")
                         }
-                        classNames.add(className)
+                        jarClassNames.add(className)
                     }
                 }
             }
         }
         def cost = (System.currentTimeMillis() - startTime) / 1000
         println "read all class file cost $cost second"
-        classNames.each {
+
+        directoryClassNames.each {
             try {
-                allClass.add(classPool.get(it));
+                allClass.add(directoryClassPool.get(it));
             } catch (javassist.NotFoundException e) {
                 println "class not found exception class name:  $it "
 
             }
+        }
 
+        jarClassNames.each {
+            try {
+                allClass.add(jarClassPool.get(it));
+            } catch (javassist.NotFoundException e) {
+                println "class not found exception class name:  $it "
+
+            }
         }
 
         Collections.sort(allClass, new Comparator<CtClass>() {

--- a/gradle-plugin/src/main/groovy/robust/gradle/plugin/RobustTransform.groovy
+++ b/gradle-plugin/src/main/groovy/robust/gradle/plugin/RobustTransform.groovy
@@ -32,6 +32,8 @@ class RobustTransform extends Transform implements Plugin<Project> {
     private static boolean isForceInsert = false;
 //    private static boolean useASM = false;
     private static boolean useASM = true;
+    private static boolean isForceInsertLambda = false;
+
     def robust
     InsertcodeStrategy insertcodeStrategy;
 
@@ -114,6 +116,10 @@ class RobustTransform extends Transform implements Plugin<Project> {
         else
             isForceInsert = false
 
+        if (robust.switch.forceInsertLambda != null && "true".equals(String.valueOf(robust.switch.forceInsertLambda.text())))
+            isForceInsertLambda = true;
+        else
+            isForceInsertLambda = false;
     }
 
     @Override
@@ -162,12 +168,13 @@ class RobustTransform extends Transform implements Plugin<Project> {
         }
 
         def box = ConvertUtils.toCtClasses(exceptCtClassNameList, inputs, directoryClassPool, jarClassPool)
+
         def cost = (System.currentTimeMillis() - startTime) / 1000
 //        logger.quiet "check all class cost $cost second, class count: ${box.size()}"
-        if(useASM){
-            insertcodeStrategy=new AsmInsertImpl(hotfixPackageList,hotfixMethodList,exceptPackageList,exceptMethodList,isHotfixMethodLevel,isExceptMethodLevel);
-        }else {
-            insertcodeStrategy=new JavaAssistInsertImpl(hotfixPackageList,hotfixMethodList,exceptPackageList,exceptMethodList,isHotfixMethodLevel,isExceptMethodLevel);
+        if (useASM) {
+            insertcodeStrategy = new AsmInsertImpl(hotfixPackageList, hotfixMethodList, exceptPackageList, exceptMethodList, isHotfixMethodLevel, isExceptMethodLevel, isForceInsertLambda);
+        } else {
+            insertcodeStrategy = new JavaAssistInsertImpl(hotfixPackageList, hotfixMethodList, exceptPackageList, exceptMethodList, isHotfixMethodLevel, isExceptMethodLevel, isForceInsertLambda);
         }
         insertcodeStrategy.insertCode(box, jarFile);
         writeMap2File(insertcodeStrategy.methodMap, Constants.METHOD_MAP_OUT_PATH)

--- a/gradle-plugin/src/main/groovy/robust/gradle/plugin/RobustTransform.groovy
+++ b/gradle-plugin/src/main/groovy/robust/gradle/plugin/RobustTransform.groovy
@@ -25,6 +25,7 @@ class RobustTransform extends Transform implements Plugin<Project> {
     private static List<String> hotfixMethodList = new ArrayList<>();
     private static List<String> exceptPackageList = new ArrayList<>();
     private static List<String> exceptMethodList = new ArrayList<>();
+    private static List<String> exceptCtClassNameList = new ArrayList<>();
     private static boolean isHotfixMethodLevel = false;
     private static boolean isExceptMethodLevel = false;
 //    private static boolean isForceInsert = true;
@@ -76,6 +77,7 @@ class RobustTransform extends Transform implements Plugin<Project> {
         hotfixMethodList = new ArrayList<>()
         exceptPackageList = new ArrayList<>()
         exceptMethodList = new ArrayList<>()
+        exceptCtClassNameList = new ArrayList<>()
         isHotfixMethodLevel = false;
         isExceptMethodLevel = false;
         /*对文件进行解析*/
@@ -91,7 +93,9 @@ class RobustTransform extends Transform implements Plugin<Project> {
         for (name in robust.exceptMethod.name) {
             exceptMethodList.add(name.text());
         }
-
+        for(name in robust.exceptCtClassName.name) {
+            exceptCtClassNameList.add(name.text());
+        }
         if (null != robust.switch.filterMethod && "true".equals(String.valueOf(robust.switch.turnOnHotfixMethod.text()))) {
             isHotfixMethodLevel = true;
         }
@@ -163,7 +167,7 @@ class RobustTransform extends Transform implements Plugin<Project> {
             jarClassPool.appendClassPath((String) it.absolutePath)
         }
 
-        def box = ConvertUtils.toCtClasses(inputs, directoryClassPool, jarClassPool)
+        def box = ConvertUtils.toCtClasses(exceptCtClassNameList, inputs, directoryClassPool, jarClassPool)
 
         def cost = (System.currentTimeMillis() - startTime) / 1000
 //        logger.quiet "check all class cost $cost second, class count: ${box.size()}"

--- a/gradle-plugin/src/main/groovy/robust/gradle/plugin/RobustTransform.groovy
+++ b/gradle-plugin/src/main/groovy/robust/gradle/plugin/RobustTransform.groovy
@@ -153,12 +153,18 @@ class RobustTransform extends Transform implements Plugin<Project> {
             jarFile.delete();
         }
 
-        ClassPool classPool = new ClassPool()
+        ClassPool directoryClassPool = new ClassPool()
         project.android.bootClasspath.each {
-            classPool.appendClassPath((String) it.absolutePath)
+            directoryClassPool.appendClassPath((String) it.absolutePath)
         }
 
-        def box = ConvertUtils.toCtClasses(inputs, classPool)
+        ClassPool jarClassPool = new ClassPool()
+        project.android.bootClasspath.each {
+            jarClassPool.appendClassPath((String) it.absolutePath)
+        }
+
+        def box = ConvertUtils.toCtClasses(inputs, directoryClassPool, jarClassPool)
+
         def cost = (System.currentTimeMillis() - startTime) / 1000
 //        logger.quiet "check all class cost $cost second, class count: ${box.size()}"
         if (useASM) {


### PR DESCRIPTION
背景：
项目打包时遇到很多第三方库混淆时会出现第三方库包名+r文件与项目生成的第三方库包名+R文件冲突导致报错问题，使用Robust才会报错，不使用是正常的。有的第三方库无法联系到开发者，如果能在Robust层面上解决，会是一种比较好的方式。

有问题的第三方库：
华为推送：maven { url 'http://developer.huawei.com/repo/' }   com.huawei.hms:push:5.0.3.301

报错：
Caused by: java.lang.RuntimeException: cannot find com.huawei.hms.hatool.r: com.huawei.hms.hatool.R found in com/huawei/hms/hatool/r.class
        at javassist.CtClassType.getClassFile2(CtClassType.java:202)
        at javassist.CtClassType.getModifiers(CtClassType.java:407)
        at robust.gradle.plugin.asm.AsmInsertImpl.insertCode(AsmInsertImpl.java:56)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)

功能说明：
尝试directoryInputs和jarInputs分别用独立的ClassPool可以修复，目前未发现更好的办法。

备注：
测试暂未发现BUG，准备上到线上环境，可以看看是否有问题。
